### PR TITLE
Add missing dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,14 +3,16 @@ uuid = "6bf848c2-a04c-470f-9a4d-5a21d02c3e16"
 version = "1.0.0"
 
 [deps]
+BufferedStreams = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 URIParser = "30578b45-9adc-5946-b283-645ec420af67"
-BufferedStreams = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"
-OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 
 [compat]
-julia = "1.4"
-URIParser = "0.4.1"
-TimeZones = "1.2.0"
-OrderedCollections = "1.2.0"
 BufferedStreams = "1.0.0"
+OrderedCollections = "1.2.0"
+TimeZones = "1.2.0"
+URIParser = "0.4.1"
+julia = "1.4"

--- a/src/julia_bolt/JuliaBolt.jl
+++ b/src/julia_bolt/JuliaBolt.jl
@@ -26,8 +26,6 @@ Original notices:
 
 module JuliaBolt
 
-using Logging
-
 using Sockets
 using BufferedStreams
 


### PR DESCRIPTION
Was running into this when loading the package:
```
ERROR: LoadError: LoadError: ArgumentError: Package Neo4jBolt does not have Logging in its dependencies:
- If you have Neo4jBolt checked out for development and have
  added Logging as a dependency but haven't updated your primary
  environment's manifest file, try `Pkg.resolve()`.
- Otherwise you may need to report an issue with Neo4jBolt
```

it seems that `Logging` is not used, but there were still some missing deps so added those.