### PR TITLE
Server metadata contains non-string types

### DIFF
--- a/src/julia_bolt/JuliaBolt.jl
+++ b/src/julia_bolt/JuliaBolt.jl
@@ -97,7 +97,7 @@ end
 mutable struct ServerInfo
     address::Tuple{IPAddr, UInt16}
     protocol_version
-    metadata::Dict{String, String}
+    metadata::Dict{String, Any}
 
     ServerInfo(address, protocol_version) = new(address, protocol_version, Dict())
 end


### PR DESCRIPTION
Hi,

Debugging a simple example, I noticed some of the values in the metadata were not strings. There was at least one dictionary, which would explain #7 (I was having the same issue).

I tried to find a place to create a test, but couldn't decide if it was necessary, nor where to create one if so. Let me know if it needs a test (some pointers on where/how to create it would be welcomel; I'm not very experienced in Julia.)

Thanks!
Bruno